### PR TITLE
Bump version to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upload-captain-artifact",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "upload-captain-artifact",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "upload-captain-artifact",
-  "version": "0.0.1",
+  "version": "1.0.0",
   "private": true,
   "description": "This action uploads artifacts, including test results, into Captain.",
   "main": "lib/main.js",


### PR DESCRIPTION
When I made the change in #104 to recommend using the `v1` branch, I forgot to update the version in package.json.