### PR TITLE
get ready for v1.0.1 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "upload-captain-artifact",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "upload-captain-artifact",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "1.10.0",


### PR DESCRIPTION
accidentally missed in #112 

💭 should we have a build step (like the one that checks the `dist` directory) to help avoid this type of missed change?