### PR TITLE
Add new bulk test results endpoints

### DIFF
--- a/src/test-suites/api/captain.test.ts
+++ b/src/test-suites/api/captain.test.ts
@@ -1,0 +1,237 @@
+import {
+  createBulkTestResults,
+  updateBulkTestResults,
+  CreateBulkTestResultsInput,
+  UpdateBulkTestResultsInput
+} from './captain'
+import fetchMock from '../../test-utils/fetch-mock'
+
+describe('Test Suites', () => {
+  describe('Captain API', () => {
+    describe('createBulkTestResults', () => {
+      const input: CreateBulkTestResultsInput = {
+        attempted_by: 'someone',
+        branch: 'some-branch',
+        commit_message: 'some-message',
+        commit_sha: 'some-sha',
+        job_tags: {
+          github_account_owner: 'some-account-owner',
+          github_repository_name: 'some-repository-name',
+          github_run_id: 'some-run-id',
+          github_run_attempt: 'some-run-attempt',
+          github_job_matrix: {some: 'value', other: 'values'},
+          github_job_name: 'some-job-name'
+        },
+        test_results_files: [
+          {
+            external_identifier: 'some-uuid',
+            format: 'some-json-format',
+            original_path: 'amongst/the/greatest/test-artifacts.json'
+          },
+          {
+            external_identifier: 'some-other-uuid',
+            format: 'some-xml-format',
+            original_path: 'an/inferior/test-artifacts.xml'
+          }
+        ],
+        test_suite_identifier: 'some-test-suite-identifier'
+      }
+
+      it('returns the test result files when the request is successful', async () => {
+        fetchMock.postOnce(
+          {
+            body: {...input, provider: 'github'},
+            headers: {Authorization: 'Bearer fake-token'},
+            url: 'https://captain.example.com/api/test_suites/bulk_test_results'
+          },
+          {
+            body: {
+              test_results_uploads: [
+                {
+                  id: 'some-id',
+                  external_identifier: 'some-uuid',
+                  upload_url: 'https://some-s3-url'
+                },
+                {
+                  id: 'some-other-id',
+                  external_identifier: 'some-other-uuid',
+                  upload_url: 'https://some-s3-url'
+                }
+              ]
+            },
+            status: 201
+          }
+        )
+
+        const result = await createBulkTestResults(input, {
+          captainBaseUrl: 'https://captain.example.com',
+          captainToken: 'fake-token'
+        })
+
+        expect(result).toEqual({
+          ok: true,
+          value: [
+            {
+              id: 'some-id',
+              external_identifier: 'some-uuid',
+              upload_url: 'https://some-s3-url'
+            },
+            {
+              id: 'some-other-id',
+              external_identifier: 'some-other-uuid',
+              upload_url: 'https://some-s3-url'
+            }
+          ]
+        })
+      })
+
+      it('returns a generic error when the request is not successful', async () => {
+        fetchMock.postOnce(
+          {
+            body: {...input, provider: 'github'},
+            headers: {Authorization: 'Bearer fake-token'},
+            url: 'https://captain.example.com/api/test_suites/bulk_test_results'
+          },
+          {
+            body: {},
+            status: 422
+          }
+        )
+
+        const result = await createBulkTestResults(input, {
+          captainBaseUrl: 'https://captain.example.com',
+          captainToken: 'fake-token'
+        })
+
+        expect(result).toEqual({
+          ok: false,
+          error: [
+            {
+              error: 'unexpected_error',
+              message:
+                'An unexpected error occurred while creating bulk test results'
+            }
+          ]
+        })
+      })
+    })
+
+    describe('updateBulkTestResults', () => {
+      const input: UpdateBulkTestResultsInput = {
+        test_suite_identifier: 'some-test-suite-identifier',
+        test_results_files: [
+          {id: 'some-id', upload_status: 'uploaded'},
+          {id: 'some-other-id', upload_status: 'upload_skipped_file_missing'}
+        ]
+      }
+
+      it('returns nothing when the request is successful', async () => {
+        fetchMock.putOnce(
+          {
+            body: input,
+            headers: {Authorization: 'Bearer fake-token'},
+            url: 'https://captain.example.com/api/test_suites/bulk_test_results'
+          },
+          {status: 204}
+        )
+
+        const result = await updateBulkTestResults(input, {
+          captainBaseUrl: 'https://captain.example.com',
+          captainToken: 'fake-token'
+        })
+
+        expect(result).toEqual({ok: true, value: undefined})
+      })
+
+      it('returns the errors when the request is not successful and has errors', async () => {
+        fetchMock.putOnce(
+          {
+            body: input,
+            headers: {Authorization: 'Bearer fake-token'},
+            url: 'https://captain.example.com/api/test_suites/bulk_test_results'
+          },
+          {
+            body: [
+              {error: 'err-one', message: 'Error one'},
+              {error: 'err-two', message: 'Error two'}
+            ],
+            status: 422
+          }
+        )
+
+        const result = await updateBulkTestResults(input, {
+          captainBaseUrl: 'https://captain.example.com',
+          captainToken: 'fake-token'
+        })
+
+        expect(result).toEqual({
+          ok: false,
+          error: [
+            {error: 'err-one', message: 'Error one'},
+            {error: 'err-two', message: 'Error two'}
+          ]
+        })
+      })
+
+      it('returns a generic error when the request is not successful and has no errors', async () => {
+        fetchMock.putOnce(
+          {
+            body: input,
+            headers: {Authorization: 'Bearer fake-token'},
+            url: 'https://captain.example.com/api/test_suites/bulk_test_results'
+          },
+          {
+            body: [],
+            status: 422
+          }
+        )
+
+        const result = await updateBulkTestResults(input, {
+          captainBaseUrl: 'https://captain.example.com',
+          captainToken: 'fake-token'
+        })
+
+        expect(result).toEqual({
+          ok: false,
+          error: [
+            {
+              error: 'unexpected_error',
+              message:
+                'An unexpected error occurred while updating bulk test results'
+            }
+          ]
+        })
+      })
+
+      it('returns a generic error when the request is not successful and has issues parsing json', async () => {
+        fetchMock.putOnce(
+          {
+            body: input,
+            headers: {Authorization: 'Bearer fake-token'},
+            url: 'https://captain.example.com/api/test_suites/bulk_test_results'
+          },
+          {
+            body: 'not json',
+            status: 500
+          }
+        )
+
+        const result = await updateBulkTestResults(input, {
+          captainBaseUrl: 'https://captain.example.com',
+          captainToken: 'fake-token'
+        })
+
+        expect(result).toEqual({
+          ok: false,
+          error: [
+            {
+              error: 'unexpected_error',
+              message:
+                'An unexpected error occurred while updating bulk test results'
+            }
+          ]
+        })
+      })
+    })
+  })
+})

--- a/src/test-suites/api/captain.ts
+++ b/src/test-suites/api/captain.ts
@@ -1,0 +1,132 @@
+import fetch from 'node-fetch'
+import Result from '../../result'
+
+type CaptainConfig = {
+  captainBaseUrl: string
+  captainToken: string
+}
+
+export type GitHubJobTags = {
+  github_account_owner: string
+  github_repository_name: string
+  github_run_id: string
+  github_run_attempt: string
+  github_job_matrix?: {[key: string]: string}
+  github_job_name: string
+}
+
+export type TestResultsFile = {
+  external_identifier: string
+  format: string
+  original_path: string
+}
+
+export type CreateBulkTestResultsInput = {
+  attempted_by: string
+  branch: string
+  commit_message?: string
+  commit_sha: string
+  job_tags: GitHubJobTags
+  test_results_files: TestResultsFile[]
+  test_suite_identifier: string
+}
+
+export type UploadStatus =
+  | 'uploaded'
+  | 'upload_skipped_file_missing'
+  | 'upload_failed'
+
+export type UpdateBulkTestResultsInput = {
+  test_suite_identifier: string
+  test_results_files: {id: string; upload_status: UploadStatus}[]
+}
+
+export type TestResultsUpload = {
+  id: string
+  external_identifier: string
+  upload_url: string
+}
+
+export type Error = {error: string; message: string}
+export type TestResultsUploads = TestResultsUpload[]
+
+const genericCreateError = [
+  {
+    error: 'unexpected_error',
+    message: 'An unexpected error occurred while creating bulk test results'
+  }
+]
+
+const genericUpdateError = [
+  {
+    error: 'unexpected_error',
+    message: 'An unexpected error occurred while updating bulk test results'
+  }
+]
+
+export async function createBulkTestResults(
+  input: CreateBulkTestResultsInput,
+  config: CaptainConfig
+): Promise<Result<TestResultsUploads, Error[]>> {
+  const response = await fetch(
+    `${config.captainBaseUrl}/api/test_suites/bulk_test_results`,
+    {
+      body: JSON.stringify({
+        ...input,
+        provider: 'github'
+      }),
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${config.captainToken}`,
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+
+  if (response.ok) {
+    return {
+      ok: true,
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      value: ((await response.json()) as any).test_results_uploads
+    }
+  } else {
+    return {
+      ok: false,
+      error: genericCreateError
+    }
+  }
+}
+
+export async function updateBulkTestResults(
+  input: UpdateBulkTestResultsInput,
+  config: CaptainConfig
+): Promise<Result<undefined, Error[]>> {
+  const response = await fetch(
+    `${config.captainBaseUrl}/api/test_suites/bulk_test_results`,
+    {
+      body: JSON.stringify(input),
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${config.captainToken}`,
+        'Content-Type': 'application/json'
+      }
+    }
+  )
+
+  if (response.ok) {
+    return {ok: true, value: undefined}
+  } else {
+    try {
+      const errors = (await response.json()) as Error[]
+      return {
+        ok: false,
+        error: errors.length ? errors : genericUpdateError
+      }
+    } catch {
+      return {
+        ok: false,
+        error: genericUpdateError
+      }
+    }
+  }
+}


### PR DESCRIPTION
In future PRs, I'll introduce a new `run.ts` (we'll call both in `main.ts` for an easier cutover) and any appropriate changes to fetch the data I need to make these requests.