### PR TITLE
Add new test-suites utils

### DIFF
--- a/src/test-suites/api/captain.ts
+++ b/src/test-suites/api/captain.ts
@@ -11,7 +11,9 @@ export type GitHubJobTags = {
   github_repository_name: string
   github_run_id: string
   github_run_attempt: string
-  github_job_matrix?: {[key: string]: string}
+  github_job_matrix?: {
+    [key: string]: string | number | boolean | null | undefined
+  }
   github_job_name: string
 }
 

--- a/src/test-suites/utils.test.ts
+++ b/src/test-suites/utils.test.ts
@@ -1,0 +1,327 @@
+import * as core from '@actions/core'
+import os from 'os'
+import path from 'path'
+import fs from 'fs'
+import {v4} from 'uuid'
+import {getInputs, Inputs} from './utils'
+
+jest.mock('@actions/core')
+
+describe('Test Suites', () => {
+  describe('Utils', () => {
+    describe('getInputs', () => {
+      function setVariable(variable: string, value: string | undefined): void {
+        const originalValue = process.env[variable]
+
+        beforeEach(() => {
+          if (value === undefined) {
+            delete process.env[variable]
+          } else {
+            process.env[variable] = value
+          }
+        })
+
+        afterEach(() => {
+          process.env[variable] = originalValue
+        })
+      }
+
+      function createTempFile(contents: string): string {
+        const filepath = path.join(os.tmpdir(), v4())
+
+        beforeEach(() => {
+          fs.writeFileSync(filepath, contents)
+        })
+
+        afterEach(() => {
+          fs.rmSync(filepath)
+        })
+
+        return filepath
+      }
+
+      setVariable('GITHUB_ACTOR', 'actor')
+      setVariable('GITHUB_EVENT_PATH', undefined)
+      setVariable('GITHUB_JOB', 'some-job')
+      setVariable('GITHUB_REF_NAME', 'some-ref-name')
+      setVariable('GITHUB_REPOSITORY', 'rwx-research/upload-captain-artifact')
+      setVariable('GITHUB_RUN_ATTEMPT', '4')
+      setVariable('GITHUB_RUN_ID', '1244592')
+      setVariable('GITHUB_SHA', 'some-commit-sha')
+      setVariable('GITHUB_TRIGGERING_ACTOR', undefined)
+
+      describe('when the payload is a pull request and there is an triggering actor', () => {
+        setVariable('GITHUB_TRIGGERING_ACTOR', 'triggering-actor')
+        setVariable(
+          'GITHUB_EVENT_PATH',
+          createTempFile(
+            JSON.stringify({
+              pull_request: {
+                head: {
+                  ref: 'some-branch'
+                }
+              }
+            })
+          )
+        )
+
+        it('parses the inputs', () => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(core.getInput as jest.Mock<any>).mockImplementation(input => {
+            if (input === 'artifacts') {
+              return '[{"kind": "test_results", "name": "Some Name", "path": "some_path.json", "parser": "rspec_json"}]'
+            } else if (input === 'if-files-not-found') {
+              return 'warn'
+            } else if (input === 'job-matrix') {
+              return '{"foo": 1, "bar": 2}'
+            } else if (input === 'job-name') {
+              return 'Some Job Name'
+            } else if (input === 'captain-base-url') {
+              return 'https://captain.example.com'
+            } else if (input === 'captain-token') {
+              return 'fake-token'
+            } else {
+              return 'nonsense'
+            }
+          })
+
+          expect(getInputs()).toEqual({
+            accountOwner: 'rwx-research',
+            attemptedBy: 'triggering-actor',
+            branch: 'some-branch',
+            captainBaseUrl: 'https://captain.example.com',
+            captainToken: 'fake-token',
+            commitMessage: undefined,
+            commitSha: 'some-commit-sha',
+            ifFilesNotFound: 'warn',
+            jobMatrix: {foo: 1, bar: 2},
+            jobName: 'Some Job Name',
+            repositoryName: 'upload-captain-artifact',
+            runAttempt: '4',
+            runId: '1244592',
+            testResultFileInputs: [
+              {
+                name: 'Some Name',
+                path: 'some_path.json',
+                format: 'rspec_json'
+              }
+            ]
+          } as Inputs)
+        })
+      })
+
+      describe('when the payload is a push and there is not an triggering actor', () => {
+        setVariable(
+          'GITHUB_EVENT_PATH',
+          createTempFile(
+            JSON.stringify({
+              head_commit: {
+                message: 'some-commit-message'
+              }
+            })
+          )
+        )
+
+        it('parses the inputs', () => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(core.getInput as jest.Mock<any>).mockImplementation(input => {
+            if (input === 'artifacts') {
+              return '[{"kind": "test_results", "name": "Some Name", "path": "some_path.json", "parser": "rspec_json"}]'
+            } else if (input === 'if-files-not-found') {
+              return 'warn'
+            } else if (input === 'job-matrix') {
+              return '{"foo": 1, "bar": 2}'
+            } else if (input === 'job-name') {
+              return 'Some Job Name'
+            } else if (input === 'captain-base-url') {
+              return 'https://captain.example.com'
+            } else if (input === 'captain-token') {
+              return 'fake-token'
+            } else {
+              return 'nonsense'
+            }
+          })
+
+          expect(getInputs()).toEqual({
+            accountOwner: 'rwx-research',
+            attemptedBy: 'actor',
+            branch: 'some-ref-name',
+            captainBaseUrl: 'https://captain.example.com',
+            captainToken: 'fake-token',
+            commitMessage: 'some-commit-message',
+            commitSha: 'some-commit-sha',
+            ifFilesNotFound: 'warn',
+            jobMatrix: {foo: 1, bar: 2},
+            jobName: 'Some Job Name',
+            repositoryName: 'upload-captain-artifact',
+            runAttempt: '4',
+            runId: '1244592',
+            testResultFileInputs: [
+              {
+                name: 'Some Name',
+                path: 'some_path.json',
+                format: 'rspec_json'
+              }
+            ]
+          } as Inputs)
+        })
+      })
+
+      describe('when the job matrix is not passed', () => {
+        it('parses the inputs', () => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(core.getInput as jest.Mock<any>).mockImplementation(input => {
+            if (input === 'artifacts') {
+              return '[{"kind": "test_results", "name": "Some Name", "path": "some_path.json", "parser": "rspec_json"}]'
+            } else if (input === 'if-files-not-found') {
+              return 'warn'
+            } else if (input === 'job-matrix') {
+              return ''
+            } else if (input === 'job-name') {
+              return 'Some Job Name'
+            } else if (input === 'captain-base-url') {
+              return 'https://captain.example.com'
+            } else if (input === 'captain-token') {
+              return 'fake-token'
+            } else {
+              return 'nonsense'
+            }
+          })
+
+          expect(getInputs()).toEqual({
+            accountOwner: 'rwx-research',
+            attemptedBy: 'actor',
+            branch: 'some-ref-name',
+            captainBaseUrl: 'https://captain.example.com',
+            captainToken: 'fake-token',
+            commitMessage: undefined,
+            commitSha: 'some-commit-sha',
+            ifFilesNotFound: 'warn',
+            jobMatrix: undefined,
+            jobName: 'Some Job Name',
+            repositoryName: 'upload-captain-artifact',
+            runAttempt: '4',
+            runId: '1244592',
+            testResultFileInputs: [
+              {
+                name: 'Some Name',
+                path: 'some_path.json',
+                format: 'rspec_json'
+              }
+            ]
+          } as Inputs)
+        })
+      })
+
+      describe('when the job name is not passed', () => {
+        it('parses the inputs', () => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(core.getInput as jest.Mock<any>).mockImplementation(input => {
+            if (input === 'artifacts') {
+              return '[{"kind": "test_results", "name": "Some Name", "path": "some_path.json", "parser": "rspec_json"}]'
+            } else if (input === 'if-files-not-found') {
+              return 'warn'
+            } else if (input === 'job-matrix') {
+              return '{"foo": 1, "bar": 2}'
+            } else if (input === 'job-name') {
+              return ''
+            } else if (input === 'captain-base-url') {
+              return 'https://captain.example.com'
+            } else if (input === 'captain-token') {
+              return 'fake-token'
+            } else {
+              return 'nonsense'
+            }
+          })
+
+          expect(getInputs()).toEqual({
+            accountOwner: 'rwx-research',
+            attemptedBy: 'actor',
+            branch: 'some-ref-name',
+            captainBaseUrl: 'https://captain.example.com',
+            captainToken: 'fake-token',
+            commitMessage: undefined,
+            commitSha: 'some-commit-sha',
+            ifFilesNotFound: 'warn',
+            jobMatrix: {foo: 1, bar: 2},
+            jobName: 'some-job',
+            repositoryName: 'upload-captain-artifact',
+            runAttempt: '4',
+            runId: '1244592',
+            testResultFileInputs: [
+              {
+                name: 'Some Name',
+                path: 'some_path.json',
+                format: 'rspec_json'
+              }
+            ]
+          } as Inputs)
+        })
+      })
+
+      describe('when artifacts are unparsable', () => {
+        it('leaves an error', () => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(core.getInput as jest.Mock<any>).mockImplementation(input => {
+            if (input === 'artifacts') {
+              return '[{"]'
+            } else if (input === 'captain-token') {
+              return 'fake-token'
+            }
+          })
+
+          expect(getInputs()).toEqual({
+            errors: ["`artifacts` field isn't valid JSON."]
+          })
+        })
+      })
+
+      describe('when artifacts are empty', () => {
+        it('leaves an error', () => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(core.getInput as jest.Mock<any>).mockImplementation(input => {
+            if (input === 'artifacts') {
+              return '[]'
+            } else if (input === 'captain-token') {
+              return 'fake-token'
+            }
+          })
+
+          expect(getInputs()).toEqual({
+            errors: [
+              'You must include at least one artifact in the `artifacts` field.'
+            ]
+          })
+        })
+      })
+
+      describe('when captain-token is missing', () => {
+        it('leaves an error', () => {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(core.getInput as jest.Mock<any>).mockImplementation(input => {
+            if (input === 'artifacts') {
+              return '[{"kind": "test_results", "name": "Some Name", "path": "some_path.json"}]'
+            }
+          })
+
+          expect(getInputs()).toEqual({
+            errors: ["`captain-token` field can't be empty."]
+          })
+
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ;(core.getInput as jest.Mock<any>).mockImplementation(input => {
+            if (input === 'artifacts') {
+              return '[{"kind": "test_results", "name": "Some Name", "path": "some_path.json"}]'
+            } else if (input === 'captain-token') {
+              return ''
+            }
+          })
+
+          expect(getInputs()).toEqual({
+            errors: ["`captain-token` field can't be empty."]
+          })
+        })
+      })
+    })
+  })
+})

--- a/src/test-suites/utils.ts
+++ b/src/test-suites/utils.ts
@@ -1,0 +1,156 @@
+import * as core from '@actions/core'
+import {GitHubJobTags} from './api/captain'
+import {existsSync, readFileSync} from 'fs'
+
+export type ArtifactInput = {
+  kind: string
+  name: string
+  path: string
+  parser: string
+}
+
+export type TestResultFileInput = {
+  name: string
+  path: string
+  format: string
+}
+
+export type IfFilesNotFound = 'ignore' | 'warn' | 'error'
+
+export type Inputs = {
+  accountOwner: string
+  attemptedBy: string
+  branch: string
+  captainBaseUrl: string
+  captainToken: string
+  commitMessage?: string
+  commitSha: string
+  ifFilesNotFound: IfFilesNotFound
+  jobMatrix?: GitHubJobTags['github_job_matrix']
+  jobName: string
+  repositoryName: string
+  runAttempt: string
+  runId: string
+  testResultFileInputs: TestResultFileInput[]
+}
+
+function parseIfFilesNotFound(input: string): IfFilesNotFound {
+  if (input === 'ignore' || input === 'warn' || input === 'error') {
+    return input
+  } else {
+    throw new Error(
+      `Unexpected value ${input} for 'if-files-not-found'. Acceptable values are 'ignore', 'warn', and 'error'`
+    )
+  }
+}
+
+function expectEnvironment(variable: string): string {
+  const value = process.env[variable]
+
+  if (value) {
+    return value
+  }
+
+  throw new Error(`process.env.${variable} was not defined`)
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function eventPayload(): any {
+  if (
+    process.env.GITHUB_EVENT_PATH &&
+    existsSync(process.env.GITHUB_EVENT_PATH)
+  ) {
+    return JSON.parse(
+      readFileSync(process.env.GITHUB_EVENT_PATH, {encoding: 'utf8'})
+    )
+  }
+}
+
+function attemptedBy(): string {
+  const triggeringActor = process.env.GITHUB_TRIGGERING_ACTOR
+  const actor = process.env.GITHUB_ACTOR
+
+  if (triggeringActor) {
+    return triggeringActor
+  }
+  if (actor) {
+    return actor
+  }
+
+  throw new Error(
+    'process.env.GITHUB_TRIGGERING_ACTOR and process.env.GITHUB_ACTOR was undefined'
+  )
+}
+
+function branch(): string {
+  const pullRequestBranch = eventPayload()?.pull_request?.head?.ref
+  if (pullRequestBranch) {
+    return pullRequestBranch
+  }
+
+  return expectEnvironment('GITHUB_REF_NAME')
+}
+
+function commitMessage(): string | undefined {
+  const pushCommitMessage = eventPayload()?.head_commit?.message
+  if (pushCommitMessage) {
+    return pushCommitMessage
+  }
+
+  return undefined
+}
+
+export type Valid = Inputs
+export type Invalid = {errors: string[]}
+export type ValidatedInputs = Valid | Invalid
+
+export function getInputs(): ValidatedInputs {
+  const matrix = core.getInput('job-matrix')
+  const errors = []
+  let artifacts: ArtifactInput[]
+
+  try {
+    artifacts = JSON.parse(core.getInput('artifacts')) as ArtifactInput[]
+    if (artifacts.length === 0) {
+      errors.push(
+        'You must include at least one artifact in the `artifacts` field.'
+      )
+    }
+  } catch (e) {
+    errors.push("`artifacts` field isn't valid JSON.")
+    artifacts = []
+  }
+
+  const captainToken = core.getInput('captain-token')
+
+  if (!captainToken || captainToken.trim().length === 0) {
+    errors.push("`captain-token` field can't be empty.")
+  }
+
+  if (errors.length !== 0) {
+    return {errors}
+  } else {
+    return {
+      accountOwner: expectEnvironment('GITHUB_REPOSITORY').split('/')[0],
+      attemptedBy: attemptedBy(),
+      branch: branch(),
+      captainBaseUrl: core.getInput('captain-base-url'),
+      captainToken,
+      commitMessage: commitMessage(),
+      commitSha: expectEnvironment('GITHUB_SHA'),
+      ifFilesNotFound: parseIfFilesNotFound(
+        core.getInput('if-files-not-found')
+      ),
+      jobMatrix: matrix ? JSON.parse(matrix) : undefined,
+      jobName: core.getInput('job-name') || expectEnvironment('GITHUB_JOB'),
+      repositoryName: expectEnvironment('GITHUB_REPOSITORY').split('/')[1],
+      runAttempt: expectEnvironment('GITHUB_RUN_ATTEMPT'),
+      runId: expectEnvironment('GITHUB_RUN_ID'),
+      testResultFileInputs: artifacts.map(({name, path, parser}) => ({
+        format: parser,
+        name,
+        path
+      }))
+    }
+  }
+}


### PR DESCRIPTION
This will be used by the upcoming new `run.ts` implementation. It gets the necessary inputs for the test-suites APIs